### PR TITLE
Fix namespace name in DatabaseHelpers

### DIFF
--- a/Enigmatry.Entry.AspNetCore.Tests.Utilities/Database/DatabaseHelpers.cs
+++ b/Enigmatry.Entry.AspNetCore.Tests.Utilities/Database/DatabaseHelpers.cs
@@ -1,10 +1,12 @@
 ﻿using Enigmatry.Entry.Core.Helpers;
+using JetBrains.Annotations;
 
 namespace Enigmatry.Entry.AspNetCore.Tests.Utilities.Database;
 
+[UsedImplicitly]
 public static class DatabaseHelpers
 {
     public static string DropAllSql =>
         EmbeddedResource.ReadResourceContent(
-            "Enigmatry.Entry.AspNetCore.Tests.Database.DropAllSql.sql", typeof(DatabaseHelpers).Assembly);
+            $"{typeof(DatabaseHelpers).Namespace}.DropAllSql.sql", typeof(DatabaseHelpers).Assembly);
 }


### PR DESCRIPTION
`Enigmatry.Entry.AspNetCore.Tests.Utilities` project is introduced in #4 , but namespace name wasn't updated.