### PR TITLE
Fixing flaky test in TimeProviderFixture

### DIFF
--- a/Enigmatry.Entry.Infrastructure.Tests/TimeProviderFixture.cs
+++ b/Enigmatry.Entry.Infrastructure.Tests/TimeProviderFixture.cs
@@ -7,22 +7,24 @@ namespace Enigmatry.Entry.Infrastructure.Tests;
 public class TimeProviderFixture
 {
     [Test]
-    public void SameTime()
+    public async Task SameTime()
     {
         var provider = new TimeProvider();
 
         var firstDate = provider.FixedUtcNow;
+        await Task.Delay(TimeSpan.FromMilliseconds(1));
         var secondDate = provider.FixedUtcNow;
 
         firstDate.Should().BeExactly(secondDate);
     }
 
     [Test]
-    public void UniqueTime()
+    public async Task UniqueTime()
     {
         var provider = new TimeProvider();
 
         var firstDate = provider.UtcNow;
+        await Task.Delay(TimeSpan.FromMilliseconds(1));
         var secondDate = provider.UtcNow;
 
         firstDate.Should().BeBefore(secondDate);


### PR DESCRIPTION
Error from TeamCity:
[dotnet test] Enigmatry.Entry.Infrastructure.Tests: Enigmatry.Entry.Infrastructure.Tests.TimeProviderFixture.UniqueTime
[Enigmatry.Entry.Infrastructure.Tests: Enigmatry.Entry.Infrastructure.Tests.TimeProviderFixture.UniqueTime] 
Expected firstDate to be before <2023-04-11 12:02:17.9521105 +0h>, but it was <2023-04-11 12:02:17.9521105 +0h>