### PR TITLE
Downgrade Azure.Search.Documents to the latest stable version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
     <PackageVersion Include="AspNetCore.HealthChecks.System" Version="6.0.5" />
     <PackageVersion Include="AutoMapper" Version="11.0.1" />
     <PackageVersion Include="Azure.Identity" Version="1.6.1" />
-    <PackageVersion Include="Azure.Search.Documents" Version="11.5.0-beta.4" />
+    <PackageVersion Include="Azure.Search.Documents" Version="11.4.0" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.13.0" />
     <PackageVersion Include="Ben.Demystifier" Version="0.4.1" />
     <PackageVersion Include="CachingFramework.Redis" Version="14.1.0" />


### PR DESCRIPTION
BP-477: Downgrade Azure.Search.Documents to the latest stable version so we can release a stable version of our package.