### PR TITLE
BP-634 Update all .NET nuget packages in the building blocks

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -21,6 +21,7 @@
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisLevel>latest</AnalysisLevel>
     <LangVersion>latest</LangVersion>
+    <NoWarn>EnableGenerateDocumentationFile</NoWarn>
 
   </PropertyGroup>
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -61,7 +61,7 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageVersion Include="MimeKit" Version="4.2.0" />
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="NJsonSchema" Version="10.9.0" />
     <PackageVersion Include="NSwag.AspNetCore" Version="13.19.0" />
     <PackageVersion Include="NUnit" Version="3.13.3" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -69,9 +69,9 @@
     <PackageVersion Include="NUnit.Analyzers" Version="3.8.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageVersion Include="Polly" Version="7.2.3" />
-    <PackageVersion Include="Quartz" Version="3.5.0" />
-    <PackageVersion Include="Quartz.Extensions.DependencyInjection" Version="3.5.0" />
-    <PackageVersion Include="Quartz.Extensions.Hosting" Version="3.5.0" />
+    <PackageVersion Include="Quartz" Version="3.7.0" />
+    <PackageVersion Include="Quartz.Extensions.DependencyInjection" Version="3.7.0" />
+    <PackageVersion Include="Quartz.Extensions.Hosting" Version="3.7.0" />
     <PackageVersion Include="Serilog" Version="2.11.0" />
     <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageVersion Include="System.Linq.Dynamic.Core" Version="1.3.3" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,8 +9,8 @@
     <PackageVersion Include="Azure.Search.Documents" Version="11.4.0" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.18.0" />
     <PackageVersion Include="Ben.Demystifier" Version="0.4.1" />
-    <PackageVersion Include="CachingFramework.Redis" Version="14.1.0" />
-    <PackageVersion Include="CachingFramework.Redis.NewtonsoftJson" Version="14.1.0" />
+    <PackageVersion Include="CachingFramework.Redis" Version="15.0.2" />
+    <PackageVersion Include="CachingFramework.Redis.NewtonsoftJson" Version="15.0.2" />
     <PackageVersion Include="coverlet.collector" Version="6.0.0" />
     <PackageVersion Include="coverlet.msbuild" Version="6.0.0" />
     <PackageVersion Include="CsvHelper" Version="30.0.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,7 +22,7 @@
     <PackageVersion Include="Humanizer.Core" Version="2.14.1" />
     <PackageVersion Include="JetBrains.Annotations" Version="2023.2.0" />
     <PackageVersion Include="MailKit" Version="4.2.0" />
-    <PackageVersion Include="MediatR" Version="10.0.1" />
+    <PackageVersion Include="MediatR" Version="12.1.1" />
     <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
     <PackageVersion Include="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore" Version="2.2.0" />
@@ -62,7 +62,7 @@
     <PackageVersion Include="MimeKit" Version="4.2.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="NJsonSchema" Version="10.9.0" />
-    <PackageVersion Include="NSwag.AspNetCore" Version="13.19.0" />
+    <PackageVersion Include="NSwag.AspNetCore" Version="13.20.0" />
     <PackageVersion Include="NUnit" Version="3.13.3" />
     <PackageVersion Include="NUnit.Analyzers" Version="3.8.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.5.0" />
@@ -72,7 +72,7 @@
     <PackageVersion Include="Quartz.Extensions.Hosting" Version="3.7.0" />
     <PackageVersion Include="Serilog" Version="2.11.0" />
     <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
-    <PackageVersion Include="System.Linq.Dynamic.Core" Version="1.3.3" />
+    <PackageVersion Include="System.Linq.Dynamic.Core" Version="1.3.5" />
     <PackageVersion Include="System.Net.Http.Json" Version="6.0.0" />
     <PackageVersion Include="System.Security.Cryptography.Algorithms" Version="4.3.1" />
     <PackageVersion Include="Verify.NUnit" Version="22.1.4" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -40,21 +40,21 @@
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="6.0.8" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.4" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.FileProviders.Physical" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.FileProviders.Physical" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="7.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />
     <PackageVersion Include="Microsoft.Graph" Version="4.36.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,7 +14,7 @@
     <PackageVersion Include="coverlet.collector" Version="6.0.0" />
     <PackageVersion Include="coverlet.msbuild" Version="6.0.0" />
     <PackageVersion Include="CsvHelper" Version="28.0.1" />
-    <PackageVersion Include="EmailValidation" Version="1.0.8" />
+    <PackageVersion Include="EmailValidation" Version="1.0.10" />
     <PackageVersion Include="FakeItEasy" Version="7.4.0" />
     <PackageVersion Include="FakeItEasy.Analyzer.CSharp" Version="6.1.1" />
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
@@ -22,7 +22,7 @@
     <PackageVersion Include="FluentValidation.AspNetCore" Version="11.0.3" />
     <PackageVersion Include="Humanizer.Core" Version="2.14.1" />
     <PackageVersion Include="JetBrains.Annotations" Version="2023.2.0" />
-    <PackageVersion Include="MailKit" Version="3.3.0" />
+    <PackageVersion Include="MailKit" Version="4.2.0" />
     <PackageVersion Include="MediatR" Version="10.0.1" />
     <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
     <PackageVersion Include="Microsoft.AspNet.WebApi.Client" Version="5.2.9" />
@@ -61,7 +61,7 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageVersion Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
-    <PackageVersion Include="MimeKit" Version="3.3.0" />
+    <PackageVersion Include="MimeKit" Version="4.2.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageVersion Include="NJsonSchema" Version="10.9.0" />
     <PackageVersion Include="NSwag.AspNetCore" Version="13.19.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -38,8 +38,8 @@
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.13" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="6.0.8" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.8" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="7.0.13" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.13" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -25,16 +25,8 @@
     <PackageVersion Include="MediatR" Version="12.1.1" />
     <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
     <PackageVersion Include="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore" Version="2.2.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Hosting" Version="2.2.7" />
-    <PackageVersion Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.2.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Localization" Version="2.2.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.2.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.13" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor" Version="2.2.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.20" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.13" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="7.0.13" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.13" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -58,7 +58,7 @@
     <PackageVersion Include="NUnit" Version="3.13.3" />
     <PackageVersion Include="NUnit.Analyzers" Version="3.8.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageVersion Include="Polly" Version="7.2.3" />
+    <PackageVersion Include="Polly" Version="8.0.0" />
     <PackageVersion Include="Quartz" Version="3.7.0" />
     <PackageVersion Include="Quartz.Extensions.DependencyInjection" Version="3.7.0" />
     <PackageVersion Include="Quartz.Extensions.Hosting" Version="3.7.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,9 +5,9 @@
   <ItemGroup>
     <PackageVersion Include="AspNetCore.HealthChecks.System" Version="6.0.5" />
     <PackageVersion Include="AutoMapper" Version="11.0.1" />
-    <PackageVersion Include="Azure.Identity" Version="1.6.1" />
+    <PackageVersion Include="Azure.Identity" Version="1.10.3" />
     <PackageVersion Include="Azure.Search.Documents" Version="11.4.0" />
-    <PackageVersion Include="Azure.Storage.Blobs" Version="12.13.0" />
+    <PackageVersion Include="Azure.Storage.Blobs" Version="12.18.0" />
     <PackageVersion Include="Ben.Demystifier" Version="0.4.1" />
     <PackageVersion Include="CachingFramework.Redis" Version="14.1.0" />
     <PackageVersion Include="CachingFramework.Redis.NewtonsoftJson" Version="14.1.0" />
@@ -59,7 +59,6 @@
     <PackageVersion Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />
     <PackageVersion Include="Microsoft.Graph" Version="4.36.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageVersion Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageVersion Include="MimeKit" Version="4.2.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,17 +11,17 @@
     <PackageVersion Include="Ben.Demystifier" Version="0.4.1" />
     <PackageVersion Include="CachingFramework.Redis" Version="14.1.0" />
     <PackageVersion Include="CachingFramework.Redis.NewtonsoftJson" Version="14.1.0" />
-    <PackageVersion Include="coverlet.collector" Version="3.1.2" />
-    <PackageVersion Include="coverlet.msbuild" Version="3.1.2" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.0" />
+    <PackageVersion Include="coverlet.msbuild" Version="6.0.0" />
     <PackageVersion Include="CsvHelper" Version="28.0.1" />
     <PackageVersion Include="EmailValidation" Version="1.0.8" />
-    <PackageVersion Include="FakeItEasy" Version="7.3.1" />
-    <PackageVersion Include="FakeItEasy.Analyzer.CSharp" Version="6.1.0" />
-    <PackageVersion Include="FluentAssertions" Version="6.7.0" />
+    <PackageVersion Include="FakeItEasy" Version="7.4.0" />
+    <PackageVersion Include="FakeItEasy.Analyzer.CSharp" Version="6.1.1" />
+    <PackageVersion Include="FluentAssertions" Version="6.12.0" />
     <PackageVersion Include="FluentValidation" Version="11.0.3" />
     <PackageVersion Include="FluentValidation.AspNetCore" Version="11.0.3" />
     <PackageVersion Include="Humanizer.Core" Version="2.14.1" />
-    <PackageVersion Include="JetBrains.Annotations" Version="2022.1.0" />
+    <PackageVersion Include="JetBrains.Annotations" Version="2023.2.0" />
     <PackageVersion Include="MailKit" Version="3.3.0" />
     <PackageVersion Include="MediatR" Version="10.0.1" />
     <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
@@ -58,7 +58,7 @@
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />
     <PackageVersion Include="Microsoft.Graph" Version="4.36.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageVersion Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageVersion Include="MimeKit" Version="3.3.0" />
@@ -66,8 +66,8 @@
     <PackageVersion Include="NJsonSchema" Version="10.9.0" />
     <PackageVersion Include="NSwag.AspNetCore" Version="13.19.0" />
     <PackageVersion Include="NUnit" Version="3.13.3" />
-    <PackageVersion Include="NUnit.Analyzers" Version="3.3.0" />
-    <PackageVersion Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageVersion Include="NUnit.Analyzers" Version="3.8.0" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageVersion Include="Polly" Version="7.2.3" />
     <PackageVersion Include="Quartz" Version="3.5.0" />
     <PackageVersion Include="Quartz.Extensions.DependencyInjection" Version="3.5.0" />
@@ -77,6 +77,6 @@
     <PackageVersion Include="System.Linq.Dynamic.Core" Version="1.3.3" />
     <PackageVersion Include="System.Net.Http.Json" Version="6.0.0" />
     <PackageVersion Include="System.Security.Cryptography.Algorithms" Version="4.3.1" />
-    <PackageVersion Include="Verify.NUnit" Version="19.8.3" />
+    <PackageVersion Include="Verify.NUnit" Version="22.1.4" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -25,7 +25,7 @@
     <PackageVersion Include="MailKit" Version="4.2.0" />
     <PackageVersion Include="MediatR" Version="10.0.1" />
     <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
-    <PackageVersion Include="Microsoft.AspNet.WebApi.Client" Version="5.2.9" />
+    <PackageVersion Include="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore" Version="2.2.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Hosting" Version="2.2.7" />
     <PackageVersion Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.2.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,8 +18,7 @@
     <PackageVersion Include="FakeItEasy" Version="7.4.0" />
     <PackageVersion Include="FakeItEasy.Analyzer.CSharp" Version="6.1.1" />
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
-    <PackageVersion Include="FluentValidation" Version="11.0.3" />
-    <PackageVersion Include="FluentValidation.AspNetCore" Version="11.0.3" />
+    <PackageVersion Include="FluentValidation" Version="11.8.0" />
     <PackageVersion Include="Humanizer.Core" Version="2.14.1" />
     <PackageVersion Include="JetBrains.Annotations" Version="2023.2.0" />
     <PackageVersion Include="MailKit" Version="4.2.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="AspNetCore.HealthChecks.System" Version="6.0.5" />
+    <PackageVersion Include="AspNetCore.HealthChecks.System" Version="7.0.0" />
     <PackageVersion Include="AutoMapper" Version="12.0.1" />
     <PackageVersion Include="Azure.Identity" Version="1.10.3" />
     <PackageVersion Include="Azure.Search.Documents" Version="11.4.0" />
@@ -73,7 +73,7 @@
     <PackageVersion Include="Serilog" Version="3.0.1" />
     <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageVersion Include="System.Linq.Dynamic.Core" Version="1.3.5" />
-    <PackageVersion Include="System.Net.Http.Json" Version="6.0.0" />
+    <PackageVersion Include="System.Net.Http.Json" Version="7.0.1" />
     <PackageVersion Include="System.Security.Cryptography.Algorithms" Version="4.3.1" />
     <PackageVersion Include="Verify.NUnit" Version="22.1.4" />
   </ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="AspNetCore.HealthChecks.System" Version="6.0.5" />
-    <PackageVersion Include="AutoMapper" Version="11.0.1" />
+    <PackageVersion Include="AutoMapper" Version="12.0.1" />
     <PackageVersion Include="Azure.Identity" Version="1.10.3" />
     <PackageVersion Include="Azure.Search.Documents" Version="11.4.0" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.18.0" />
@@ -70,7 +70,7 @@
     <PackageVersion Include="Quartz" Version="3.7.0" />
     <PackageVersion Include="Quartz.Extensions.DependencyInjection" Version="3.7.0" />
     <PackageVersion Include="Quartz.Extensions.Hosting" Version="3.7.0" />
-    <PackageVersion Include="Serilog" Version="2.11.0" />
+    <PackageVersion Include="Serilog" Version="3.0.1" />
     <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageVersion Include="System.Linq.Dynamic.Core" Version="1.3.5" />
     <PackageVersion Include="System.Net.Http.Json" Version="6.0.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -35,7 +35,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.13" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor" Version="2.2.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.20" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.13" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.13" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="7.0.13" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,7 +13,7 @@
     <PackageVersion Include="CachingFramework.Redis.NewtonsoftJson" Version="14.1.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.0" />
     <PackageVersion Include="coverlet.msbuild" Version="6.0.0" />
-    <PackageVersion Include="CsvHelper" Version="28.0.1" />
+    <PackageVersion Include="CsvHelper" Version="30.0.1" />
     <PackageVersion Include="EmailValidation" Version="1.0.10" />
     <PackageVersion Include="FakeItEasy" Version="7.4.0" />
     <PackageVersion Include="FakeItEasy.Analyzer.CSharp" Version="6.1.1" />

--- a/Enigmatry.Entry.AspNetCore.Authorization.Tests/Enigmatry.Entry.AspNetCore.Authorization.Tests.csproj
+++ b/Enigmatry.Entry.AspNetCore.Authorization.Tests/Enigmatry.Entry.AspNetCore.Authorization.Tests.csproj
@@ -14,8 +14,14 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
-    <PackageReference Include="NUnit.Analyzers" />
-    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="NUnit.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Enigmatry.Entry.AspNetCore.Tests.NewtonsoftJson.Tests/Enigmatry.Entry.AspNetCore.Tests.NewtonsoftJson.Tests.csproj
+++ b/Enigmatry.Entry.AspNetCore.Tests.NewtonsoftJson.Tests/Enigmatry.Entry.AspNetCore.Tests.NewtonsoftJson.Tests.csproj
@@ -12,7 +12,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
-    <PackageReference Include="NUnit.Analyzers" />
+    <PackageReference Include="NUnit.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Enigmatry.Entry.AspNetCore.Tests.NewtonsoftJson\Enigmatry.Entry.AspNetCore.Tests.NewtonsoftJson.csproj" />

--- a/Enigmatry.Entry.AspNetCore.Tests.NewtonsoftJson.Tests/Enigmatry.Entry.AspNetCore.Tests.NewtonsoftJson.Tests.csproj
+++ b/Enigmatry.Entry.AspNetCore.Tests.NewtonsoftJson.Tests/Enigmatry.Entry.AspNetCore.Tests.NewtonsoftJson.Tests.csproj
@@ -8,7 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" VersionOverride="6.0.24" Condition=" '$(TargetFramework)' == 'net6.0' " />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Condition=" '$(TargetFramework)' == 'net7.0' " />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
@@ -17,6 +18,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Enigmatry.Entry.AspNetCore.Tests.NewtonsoftJson\Enigmatry.Entry.AspNetCore.Tests.NewtonsoftJson.csproj" />
     <ProjectReference Include="..\Enigmatry.Entry.AspNetCore.Tests\Enigmatry.Entry.AspNetCore.Tests.csproj" />

--- a/Enigmatry.Entry.AspNetCore.Tests.NewtonsoftJson/Http/HttpResponseMessageExtensions.cs
+++ b/Enigmatry.Entry.AspNetCore.Tests.NewtonsoftJson/Http/HttpResponseMessageExtensions.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Rest;
-using System.Net.Http;
+﻿using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace Enigmatry.Entry.AspNetCore.Tests.NewtonsoftJson.Http;
@@ -29,15 +28,15 @@ public static class HttpResponseMessageExtensions
         }
     }
 
-    private static HttpOperationException DisposeResponseContentAndThrowException(HttpResponseMessage response,
+    private static HttpRequestException DisposeResponseContentAndThrowException(HttpResponseMessage response,
         string content)
     {
         // Disposing the content should help users: If users call EnsureSuccessStatusCode(), an exception is
         // thrown if the statusCode status code is != 2xx. I.e. the behavior is similar to a failed request (e.g.
         // connection failure). Users are not expected to dispose the content in this case: If an exception is 
-        // thrown, the object is responsible fore cleaning up its state.
+        // thrown, the object is responsible for cleaning up its state.
         response.Content?.Dispose();
-        throw new HttpOperationException(
+        throw new HttpRequestException(
             $"StatusCode: {response.StatusCode}, ReasonPhrase: {response.ReasonPhrase}, RequestUri: {response.RequestMessage?.RequestUri}, Content: {content}.");
     }
 }

--- a/Enigmatry.Entry.AspNetCore.Tests.SampleApp/Enigmatry.Entry.AspNetCore.Tests.SampleApp.csproj
+++ b/Enigmatry.Entry.AspNetCore.Tests.SampleApp/Enigmatry.Entry.AspNetCore.Tests.SampleApp.csproj
@@ -7,8 +7,10 @@
     <Description>Sample AspNetCore application</Description>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
+
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" VersionOverride="6.0.24" Condition=" '$(TargetFramework)' == 'net6.0' " />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Condition=" '$(TargetFramework)' == 'net7.0' " />
   </ItemGroup>
 
   <ItemGroup>

--- a/Enigmatry.Entry.AspNetCore.Tests.SystemTextJson.Tests/Enigmatry.Entry.AspNetCore.Tests.SystemTextJson.Tests.csproj
+++ b/Enigmatry.Entry.AspNetCore.Tests.SystemTextJson.Tests/Enigmatry.Entry.AspNetCore.Tests.SystemTextJson.Tests.csproj
@@ -11,8 +11,14 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
-    <PackageReference Include="NUnit.Analyzers" />
-    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="NUnit.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Enigmatry.Entry.AspNetCore.Tests.SystemTextJson/Http/HttpResponseMessageExtensions.cs
+++ b/Enigmatry.Entry.AspNetCore.Tests.SystemTextJson/Http/HttpResponseMessageExtensions.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Rest;
-using System.Net.Http;
+﻿using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace Enigmatry.Entry.AspNetCore.Tests.SystemTextJson.Http;
@@ -29,15 +28,15 @@ public static class HttpResponseMessageExtensions
         }
     }
 
-    private static HttpOperationException DisposeResponseContentAndThrowException(HttpResponseMessage response,
+    private static HttpRequestException DisposeResponseContentAndThrowException(HttpResponseMessage response,
         string content)
     {
         // Disposing the content should help users: If users call EnsureSuccessStatusCode(), an exception is
         // thrown if the statusCode status code is != 2xx. I.e. the behavior is similar to a failed request (e.g.
         // connection failure). Users are not expected to dispose the content in this case: If an exception is 
-        // thrown, the object is responsible fore cleaning up its state.
+        // thrown, the object is responsible for cleaning up its state.
         response.Content?.Dispose();
-        throw new HttpOperationException(
+        throw new HttpRequestException(
             $"StatusCode: {response.StatusCode}, ReasonPhrase: {response.ReasonPhrase}, RequestUri: {response.RequestMessage?.RequestUri}, Content: {content}.");
     }
 }

--- a/Enigmatry.Entry.AspNetCore.Tests.Utilities/Enigmatry.Entry.AspNetCore.Tests.Utilities.csproj
+++ b/Enigmatry.Entry.AspNetCore.Tests.Utilities/Enigmatry.Entry.AspNetCore.Tests.Utilities.csproj
@@ -16,7 +16,6 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
-    <PackageReference Include="Microsoft.Rest.ClientRuntime" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" />
     <PackageReference Include="System.Net.Http.Json" />
   </ItemGroup>

--- a/Enigmatry.Entry.AspNetCore.Tests/Enigmatry.Entry.AspNetCore.Tests.csproj
+++ b/Enigmatry.Entry.AspNetCore.Tests/Enigmatry.Entry.AspNetCore.Tests.csproj
@@ -13,7 +13,6 @@
   <ItemGroup>
     <PackageReference Include="FakeItEasy" />
     <PackageReference Include="FluentAssertions" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
@@ -26,6 +25,14 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Verify.NUnit" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" VersionOverride="6.0.24" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Enigmatry.Entry.AspNetCore.Tests/Enigmatry.Entry.AspNetCore.Tests.csproj
+++ b/Enigmatry.Entry.AspNetCore.Tests/Enigmatry.Entry.AspNetCore.Tests.csproj
@@ -17,8 +17,14 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
-    <PackageReference Include="NUnit.Analyzers" />
-    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="NUnit.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Verify.NUnit" />
   </ItemGroup>
 

--- a/Enigmatry.Entry.AspNetCore.Tests/Enigmatry.Entry.AspNetCore.Tests.csproj
+++ b/Enigmatry.Entry.AspNetCore.Tests/Enigmatry.Entry.AspNetCore.Tests.csproj
@@ -13,6 +13,8 @@
   <ItemGroup>
     <PackageReference Include="FakeItEasy" />
     <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" VersionOverride="6.0.24" Condition=" '$(TargetFramework)' == 'net6.0' " />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Condition=" '$(TargetFramework)' == 'net7.0' "/>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
@@ -25,14 +27,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Verify.NUnit" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" VersionOverride="6.0.24" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Enigmatry.Entry.AspNetCore/Enigmatry.Entry.AspNetCore.csproj
+++ b/Enigmatry.Entry.AspNetCore/Enigmatry.Entry.AspNetCore.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper" />
     <PackageReference Include="Ben.Demystifier" />
-    <PackageReference Include="FluentValidation.AspNetCore" />
+    <PackageReference Include="FluentValidation" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" />
   </ItemGroup>

--- a/Enigmatry.Entry.AzureSearch.Tests/Enigmatry.Entry.AzureSearch.Tests.csproj
+++ b/Enigmatry.Entry.AzureSearch.Tests/Enigmatry.Entry.AzureSearch.Tests.csproj
@@ -19,8 +19,14 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
-    <PackageReference Include="NUnit.Analyzers" />
-    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="NUnit.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Verify.NUnit" />
   </ItemGroup>
 

--- a/Enigmatry.Entry.AzureSearch.Tests/SearchIndexClientFixture.cs
+++ b/Enigmatry.Entry.AzureSearch.Tests/SearchIndexClientFixture.cs
@@ -22,6 +22,9 @@ public class SearchIndexClientFixture
         _indexFactory = _services.GetRequiredService<ISearchIndexFactory<TestDocument>>();
     }
 
+    [TearDown]
+    public void TearDown() => _services.Dispose();
+
     [Test]
     public async Task TestCreateOrUpdateIndex()
     {

--- a/Enigmatry.Entry.AzureSearch.Tests/SearchIndexFactoryResolvingFixture.cs
+++ b/Enigmatry.Entry.AzureSearch.Tests/SearchIndexFactoryResolvingFixture.cs
@@ -14,6 +14,9 @@ public class SearchIndexFactoryResolvingFixture
     [SetUp]
     public void Setup() => _services = new ServiceCollectionBuilder().Build();
 
+    [TearDown]
+    public void TearDown() => _services.Dispose();
+
     [Test]
     public void TestResolveSearchIndexTestDocument()
     {

--- a/Enigmatry.Entry.AzureSearch.Tests/SearchIndexManagerFixture.cs
+++ b/Enigmatry.Entry.AzureSearch.Tests/SearchIndexManagerFixture.cs
@@ -20,6 +20,9 @@ public class SearchIndexManagerFixture
         _indexManager = _services.GetRequiredService<ISearchIndexManager<TestDocument>>();
     }
 
+    [TearDown]
+    public void TearDown() => _services.Dispose();
+
     [Test]
     public async Task TestRebuildIndex() => await _indexManager.RecreateIndex();
 

--- a/Enigmatry.Entry.AzureSearch.Tests/SearchTextFixture.cs
+++ b/Enigmatry.Entry.AzureSearch.Tests/SearchTextFixture.cs
@@ -9,7 +9,7 @@ public class SearchTextFixture
     [TestCase("", "")]
     [TestCase("some", "some")]
     [TestCase("some+", "some+")]
-    public void TestAsNotEscaped(string value, string expectedValue)
+    public void TestAsNotEscaped(string? value, string expectedValue)
     {
         var searchText = SearchText.AsNotEscaped(value);
         searchText.OriginalValue.Should().Be(value);
@@ -20,7 +20,7 @@ public class SearchTextFixture
     [TestCase("", "")]
     [TestCase("some", "some")]
     [TestCase("some+", "some\\+")]
-    public void TestAsEscaped(string value, string expectedValue)
+    public void TestAsEscaped(string? value, string expectedValue)
     {
         var searchText = SearchText.AsEscaped(value);
         searchText.OriginalValue.Should().Be(value);
@@ -32,7 +32,7 @@ public class SearchTextFixture
     [TestCase("some", "\"some\"")]
     [TestCase("some+", "\"some\\+\"")]
     [TestCase("first last", "\"first last\"")]
-    public void TestAsPhraseSearch(string value, string expectedValue)
+    public void TestAsPhraseSearch(string? value, string expectedValue)
     {
         var searchText = SearchText.AsPhraseSearch(value);
         searchText.OriginalValue.Should().Be(value);
@@ -44,7 +44,7 @@ public class SearchTextFixture
     [TestCase("some", "\"some\" OR some* OR some~1")]
     [TestCase("some+", "\"some\\+\" OR some\\+* OR some\\+~1")]
     [TestCase("first last", "\"first last\" OR (+first +last)")]
-    public void TestAsFullSearch(string value, string expectedValue)
+    public void TestAsFullSearch(string? value, string expectedValue)
     {
         var searchText = SearchText.AsFullSearch(value);
         searchText.OriginalValue.Should().Be(value);

--- a/Enigmatry.Entry.AzureSearch.Tests/Searching/FacetedSearchFixture.cs
+++ b/Enigmatry.Entry.AzureSearch.Tests/Searching/FacetedSearchFixture.cs
@@ -16,7 +16,7 @@ public class FacetedSearchFixture : SearchServiceFixtureBase
     [TestCase("")]
     [TestCase(null)]
     [TestCase("name1")]
-    public async Task TestSearchWithFacets(string searchText)
+    public async Task TestSearchWithFacets(string? searchText)
     {
         var options = ASearchOptionsWithFaceting();
 

--- a/Enigmatry.Entry.AzureSearch.Tests/Searching/FilterSearchFixture.cs
+++ b/Enigmatry.Entry.AzureSearch.Tests/Searching/FilterSearchFixture.cs
@@ -24,7 +24,7 @@ public class FilterSearchFixture : SearchServiceFixtureBase
 
     [TestCase(null)]
     [TestCase("")]
-    public async Task TestSearchWithEmptyStatement(string statement)
+    public async Task TestSearchWithEmptyStatement(string? statement)
     {
         var filterBuilder = new AzureSearchFilterBuilder();
         filterBuilder.AddStatement(statement);

--- a/Enigmatry.Entry.AzureSearch.Tests/Searching/HighlightedSearchFixture.cs
+++ b/Enigmatry.Entry.AzureSearch.Tests/Searching/HighlightedSearchFixture.cs
@@ -17,7 +17,7 @@ public class HighlightedSearchFixture : SearchServiceFixtureBase
     [TestCase(null)]
     [TestCase("name1")]
     [TestCase("lorem")]
-    public async Task TestSearchWithHighlights(string searchText)
+    public async Task TestSearchWithHighlights(string? searchText)
     {
         var options = ASearchOptionsWithHighlighting();
 

--- a/Enigmatry.Entry.AzureSearch.Tests/Searching/SearchServiceFixtureBase.cs
+++ b/Enigmatry.Entry.AzureSearch.Tests/Searching/SearchServiceFixtureBase.cs
@@ -25,6 +25,9 @@ public abstract class SearchServiceFixtureBase
         WaitIndexToBeUpdated();
     }
 
+    [OneTimeTearDown]
+    public void OneTimeTearDown() => _services.Dispose();
+
     [SetUp]
     public async Task Setup() => await DeleteAllDocuments(); // remove all leftovers from previous test run
 

--- a/Enigmatry.Entry.AzureSearch.Tests/Setup/ServiceCollectionBuilder.cs
+++ b/Enigmatry.Entry.AzureSearch.Tests/Setup/ServiceCollectionBuilder.cs
@@ -23,8 +23,8 @@ public class ServiceCollectionBuilder
 
         _services.AddAzureSearch(configure =>
             {
-                configure.ApiKey = configuration[AzureSearchApiKey];
-                configure.SearchServiceEndPoint = new Uri(configuration[AzureSearchSearchServiceEndpointKey]);
+                configure.ApiKey = configuration[AzureSearchApiKey]!;
+                configure.SearchServiceEndPoint = new Uri(configuration[AzureSearchSearchServiceEndpointKey]!);
             })
             .AddDocument<TestDocument>()
             .AddSearchIndexFactory<TestDocumentSearchIndexFactory>()
@@ -37,7 +37,7 @@ public class ServiceCollectionBuilder
     {
         var configurationSource = new MemoryConfigurationSource
         {
-            InitialData = new Dictionary<string, string>
+            InitialData = new Dictionary<string, string?>
             {
                 { AzureSearchApiKey, "USER_SECRET" }, { AzureSearchSearchServiceEndpointKey, "USER_SECRET" }
             }

--- a/Enigmatry.Entry.AzureSearch/AzureSearchFilterBuilder.cs
+++ b/Enigmatry.Entry.AzureSearch/AzureSearchFilterBuilder.cs
@@ -25,7 +25,7 @@ public class AzureSearchFilterBuilder
         CloseBracket();
     }
 
-    public void AddStatement(string statement)
+    public void AddStatement(string? statement)
     {
         if (statement.HasContent())
         {
@@ -54,7 +54,7 @@ public class AzureSearchFilterBuilder
         }
     }
 
-    private void Append(string condition) => _searchFilter.Append(condition);
+    private void Append(string? condition) => _searchFilter.Append(condition);
 
     public string Build() => _searchFilter.ToString();
 }

--- a/Enigmatry.Entry.AzureSearch/SearchText.cs
+++ b/Enigmatry.Entry.AzureSearch/SearchText.cs
@@ -4,32 +4,32 @@ namespace Enigmatry.Entry.AzureSearch;
 
 public record SearchText
 {
-    private SearchText(string originalValue, string value)
+    private SearchText(string? originalValue, string value)
     {
         OriginalValue = originalValue;
         Value = value;
     }
 
-    public static SearchText AsNotEscaped(string searchText) => new(searchText, searchText.ToEmptyIfNull());
+    public static SearchText AsNotEscaped(string? searchText) => new(searchText, searchText.ToEmptyIfNull());
 
-    public static SearchText AsEscaped(string searchText)
+    public static SearchText AsEscaped(string? searchText)
     {
         var result = searchText.ToEmptyIfNull().EscapeSpecialSymbols();
         return new SearchText(searchText, result);
     }
 
-    public static SearchText AsPhraseSearch(string searchText)
+    public static SearchText AsPhraseSearch(string? searchText)
     {
         var result = searchText.ToEmptyIfNull().EscapeSpecialSymbols().AsPhraseSearch();
         return new SearchText(searchText, result);
     }
 
-    public static SearchText AsFullSearch(string searchText)
+    public static SearchText AsFullSearch(string? searchText)
     {
         var result = searchText.ToEmptyIfNull().EscapeSpecialSymbols().AsFullSearch();
         return new SearchText(searchText, result);
     }
 
-    public string OriginalValue { get; }
+    public string? OriginalValue { get; }
     public string Value { get; }
 }

--- a/Enigmatry.Entry.BlobStorage.Tests/AzurePrivateBlobStorageFixture.cs
+++ b/Enigmatry.Entry.BlobStorage.Tests/AzurePrivateBlobStorageFixture.cs
@@ -53,8 +53,8 @@ public class AzurePrivateBlobStorageFixture
     {
         var path = "https://testaccount.blob.core.windows.net:443" +
                    "/testContainer/testResource.pdf" +
-                   "?sv=2021-08-06&spr=https&se=2022-08-10T12%3A26%3A47Z&sr=b&sp=r" +
-                   "&sig=oWr83Y83Is%2Fyxlai1U7dTFK6ckYoy4IhKVFV2KFwhLU%3D";
+                   "?sv=2023-08-03&spr=https&se=2022-08-10T12%3A26%3A47Z&sr=b&sp=r" +
+                   "&sig=PkWAXLYeYlKxZuCkPlyJ2TYJ4whscQznBdK4AZYc0KI%3D";
 
         _blobStorage.VerifySharedResourcePath(new Uri(path)).Should().BeTrue();
     }
@@ -64,8 +64,8 @@ public class AzurePrivateBlobStorageFixture
     {
         var path = "https://testaccount.blob.core.windows.net:443" +
                    "/testContainer/testResource.pdf" +
-                   "?sv=2021-08-06&spr=https&se=2022-08-10T12%3A26%3A47Z&sr=b&sp=w" +
-                   "&sig=oWr83Y83Is%2Fyxlai1U7dTFK6ckYoy4IhKVFV2KFwhLU%3D";
+                   "?sv=2023-08-03&spr=https&se=2022-08-10T12%3A26%3A47Z&sr=b&sp=w" +
+                   "&sig=PkWAXLYeYlKxZuCkPlyJ2TYJ4whscQznBdK4AZYc0KI%3D";
         _blobStorage.VerifySharedResourcePath(new Uri(path)).Should().BeFalse();
     }
 
@@ -74,8 +74,9 @@ public class AzurePrivateBlobStorageFixture
     {
         var path = "https://testaccount.blob.core.windows.net:443" +
                    "/testContainer/testResource.pdf" +
-                   "?sv=2021-08-06&spr=https&se=2022-08-10T12%3A26%3A47Z&sr=b&sp=r" +
-                   "&sig=OWr83Y83Is%2Fyxlai1U7dTFK6ckYoy4IhKVFV2KFwhLU%3D";
+                   "?sv=2023-08-03&spr=https&se=2022-08-10T12%3A26%3A47Z&sr=b&sp=r" +
+                   "&sig=pkWAXLYeYlKxZuCkPlyJ2TYJ4whscQznBdK4AZYc0KI%3D";
+
         _blobStorage.VerifySharedResourcePath(new Uri(path)).Should().BeFalse();
     }
 
@@ -84,8 +85,8 @@ public class AzurePrivateBlobStorageFixture
     {
         var path = "https://testaccount.blob.core.windows.net:443" +
                    "/testContainer/testResourcee.pdf" +
-                   "?sv=2021-08-06&spr=https&se=2022-08-10T12%3A26%3A47Z&sr=b&sp=r" +
-                   "&sig=oWr83Y83Is%2Fyxlai1U7dTFK6ckYoy4IhKVFV2KFwhLU%3D";
+                   "?sv=2023-08-03&spr=https&se=2022-08-10T12%3A26%3A47Z&sr=b&sp=r" +
+                   "&sig=PkWAXLYeYlKxZuCkPlyJ2TYJ4whscQznBdK4AZYc0KI%3D";
         _blobStorage.VerifySharedResourcePath(new Uri(path)).Should().BeFalse();
     }
 }

--- a/Enigmatry.Entry.BlobStorage.Tests/Enigmatry.Entry.BlobStorage.Tests.csproj
+++ b/Enigmatry.Entry.BlobStorage.Tests/Enigmatry.Entry.BlobStorage.Tests.csproj
@@ -11,8 +11,14 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
-    <PackageReference Include="NUnit.Analyzers" />
-    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="NUnit.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Enigmatry.Entry.CacheManager/MemoryCacheCacheManager.cs
+++ b/Enigmatry.Entry.CacheManager/MemoryCacheCacheManager.cs
@@ -20,8 +20,12 @@ namespace Enigmatry.Entry.CacheManager
 
         public void Set<T>(string key, T value, TimeSpan timeout) => _cache.Set(key, value, timeout);
 
+#pragma warning disable IDE0060 // Remove unused parameter
         public void AddItemToSortedSet(string setId, object value, double score) => throw new NotSupportedException("Not supported by memory cache.");
+#pragma warning restore IDE0060 // Remove unused parameter
 
+#pragma warning disable IDE0060 // Remove unused parameter
         public void AddItemToList(string listId, object value) => throw new NotSupportedException("Not supported by memory cache.");
+#pragma warning restore IDE0060 // Remove unused parameter
     }
 }

--- a/Enigmatry.Entry.CacheManager/MemoryCacheCacheManager.cs
+++ b/Enigmatry.Entry.CacheManager/MemoryCacheCacheManager.cs
@@ -16,16 +16,12 @@ namespace Enigmatry.Entry.CacheManager
 
         public void RemoveAllByPattern(string pattern) => throw new NotSupportedException("Not supported by memory cache.");
 
-        public T? Get<T>(string key) => _cache.TryGetValue(key, out var value) ? (T)value : default;
+        public T? Get<T>(string key) => _cache.TryGetValue(key, out var value) ? (T?)value : default;
 
         public void Set<T>(string key, T value, TimeSpan timeout) => _cache.Set(key, value, timeout);
 
-#pragma warning disable IDE0060 // Remove unused parameter
         public void AddItemToSortedSet(string setId, object value, double score) => throw new NotSupportedException("Not supported by memory cache.");
-#pragma warning restore IDE0060 // Remove unused parameter
 
-#pragma warning disable IDE0060 // Remove unused parameter
         public void AddItemToList(string listId, object value) => throw new NotSupportedException("Not supported by memory cache.");
-#pragma warning restore IDE0060 // Remove unused parameter
     }
 }

--- a/Enigmatry.Entry.Core.Tests/Enigmatry.Entry.Core.Tests.csproj
+++ b/Enigmatry.Entry.Core.Tests/Enigmatry.Entry.Core.Tests.csproj
@@ -12,8 +12,14 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
-    <PackageReference Include="NUnit.Analyzers" />
-    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="NUnit.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Enigmatry.Entry.Core/Enigmatry.Entry.Core.csproj
+++ b/Enigmatry.Entry.Core/Enigmatry.Entry.Core.csproj
@@ -11,18 +11,11 @@
 
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" />
+    <PackageReference Include="MediatR" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" />
     <PackageReference Include="Serilog" />
     <PackageReference Include="System.ComponentModel.Annotations" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="MediatR" VersionOverride="9.0.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
-    <PackageReference Include="MediatR" />
   </ItemGroup>
 
 </Project>

--- a/Enigmatry.Entry.Core/Helpers/StringExtensions.cs
+++ b/Enigmatry.Entry.Core/Helpers/StringExtensions.cs
@@ -7,8 +7,8 @@ namespace Enigmatry.Entry.Core.Helpers;
 
 public static class StringExtensions
 {
-    public static bool HasNoContent(this string value) => !value.HasContent();
-    public static bool HasContent(this string value) => !string.IsNullOrEmpty(value);
+    public static bool HasNoContent(this string? value) => !value.HasContent();
+    public static bool HasContent(this string? value) => !string.IsNullOrEmpty(value);
 
     public static bool Contains(this string source, string value, StringComparison comparisonType) =>
         source.Contains(value, comparisonType);

--- a/Enigmatry.Entry.Csv.Tests/Enigmatry.Entry.Csv.Tests.csproj
+++ b/Enigmatry.Entry.Csv.Tests/Enigmatry.Entry.Csv.Tests.csproj
@@ -11,8 +11,14 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
-    <PackageReference Include="NUnit.Analyzers" />
-    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="NUnit.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Enigmatry.Entry.Csv/DateTimeOffsetToLocalDateTimeConverter.cs
+++ b/Enigmatry.Entry.Csv/DateTimeOffsetToLocalDateTimeConverter.cs
@@ -7,7 +7,7 @@ namespace Enigmatry.Entry.Csv
 {
     public class DateTimeOffsetToLocalDateTimeConverter : DefaultTypeConverter
     {
-        public override string ConvertToString(object value, IWriterRow row, MemberMapData memberMapData) =>
+        public override string? ConvertToString(object? value, IWriterRow row, MemberMapData memberMapData) =>
             value is DateTimeOffset dateTimeOffset
                 ? dateTimeOffset.LocalDateTime.ToString("yyyy-MM-dd HH:mm:ss")
                 : base.ConvertToString(value, row, memberMapData);

--- a/Enigmatry.Entry.Email.Tests/Enigmatry.Entry.Email.Tests.csproj
+++ b/Enigmatry.Entry.Email.Tests/Enigmatry.Entry.Email.Tests.csproj
@@ -14,8 +14,14 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
-    <PackageReference Include="NUnit.Analyzers" />
-    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="NUnit.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Enigmatry.Entry.EmailClient/EmailClientStartupExtension.cs
+++ b/Enigmatry.Entry.EmailClient/EmailClientStartupExtension.cs
@@ -1,4 +1,5 @@
-﻿using Enigmatry.Entry.Core.Settings;
+﻿using System;
+using Enigmatry.Entry.Core.Settings;
 using Enigmatry.Entry.Email.MailKit;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -9,9 +10,17 @@ namespace Enigmatry.Entry.Email
     {
         public static void AppAddEmailClient(this IServiceCollection services, IConfiguration configuration)
         {
-            services.Configure<SmtpSettings>(configuration.GetSection(SmtpSettings.AppSmtp));
+            var section = configuration.GetSection(SmtpSettings.AppSmtp);
 
-            var smtpSettings = configuration.GetSection(SmtpSettings.AppSmtp).Get<SmtpSettings>();
+            if (!section.Exists())
+            {
+                throw new InvalidOperationException(
+                    $"Section is missing from configuration. Section Name: {SmtpSettings.AppSmtp}");
+            }
+
+            services.Configure<SmtpSettings>(section);
+
+            var smtpSettings = section.Get<SmtpSettings>()!;
 
             if (smtpSettings.UsePickupDirectory)
             {

--- a/Enigmatry.Entry.HealthChecks.Tests/Enigmatry.Entry.HealthChecks.Tests.csproj
+++ b/Enigmatry.Entry.HealthChecks.Tests/Enigmatry.Entry.HealthChecks.Tests.csproj
@@ -23,7 +23,10 @@
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
     <PackageReference Include="FluentAssertions" />
-    <PackageReference Include="NUnit.Analyzers" />
+    <PackageReference Include="NUnit.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Enigmatry.Entry.Infrastructure.Tests/Enigmatry.Entry.Infrastructure.Tests.csproj
+++ b/Enigmatry.Entry.Infrastructure.Tests/Enigmatry.Entry.Infrastructure.Tests.csproj
@@ -20,7 +20,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FakeItEasy"/>
+    <PackageReference Include="FakeItEasy" />
     <PackageReference Include="FakeItEasy.Analyzer.CSharp">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -29,7 +29,10 @@
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
     <PackageReference Include="FluentAssertions" />
-    <PackageReference Include="NUnit.Analyzers" />
+    <PackageReference Include="NUnit.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Enigmatry.Entry.MediatR/Enigmatry.Entry.MediatR.csproj
+++ b/Enigmatry.Entry.MediatR/Enigmatry.Entry.MediatR.csproj
@@ -14,13 +14,6 @@
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" />
     <PackageReference Include="Serilog" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="MediatR" VersionOverride="9.0.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
     <PackageReference Include="MediatR" />
   </ItemGroup>
 

--- a/Enigmatry.Entry.MediatR/Enigmatry.Entry.MediatR.csproj
+++ b/Enigmatry.Entry.MediatR/Enigmatry.Entry.MediatR.csproj
@@ -11,10 +11,10 @@
 
   <ItemGroup>
     <PackageReference Include="FluentValidation" />
+    <PackageReference Include="MediatR" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" />
     <PackageReference Include="Serilog" />
-    <PackageReference Include="MediatR" />
   </ItemGroup>
 
 </Project>

--- a/Enigmatry.Entry.MediatR/LoggingBehavior.cs
+++ b/Enigmatry.Entry.MediatR/LoggingBehavior.cs
@@ -15,8 +15,7 @@ namespace Enigmatry.Entry.MediatR
             _logger = logger;
         }
 
-        public async Task<TResponse> Handle(TRequest request, CancellationToken cancellationToken,
-            RequestHandlerDelegate<TResponse> next)
+        public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
         {
             var requestType = typeof(TRequest).FullName;
             using (LogContext.PushProperty("MediatRRequestType", requestType))

--- a/Enigmatry.Entry.MediatR/NullMediator.cs
+++ b/Enigmatry.Entry.MediatR/NullMediator.cs
@@ -1,34 +1,35 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
 
-namespace Enigmatry.Entry.MediatR
+namespace Enigmatry.Entry.MediatR;
+
+public class NullMediator : IMediator
 {
-    public class NullMediator : IMediator
-    {
-        public Task Publish(object notification, CancellationToken cancellationToken = default) =>
-            Task.CompletedTask;
+    public Task Publish(object notification, CancellationToken cancellationToken = default) =>
+        Task.CompletedTask;
 
-        public Task Publish<TNotification>(TNotification notification,
-            CancellationToken cancellationToken = default) where TNotification : INotification =>
-            Task.CompletedTask;
+    public Task Publish<TNotification>(TNotification notification,
+        CancellationToken cancellationToken = default) where TNotification : INotification =>
+        Task.CompletedTask;
 
-        public Task<TResponse> Send<TResponse>(IRequest<TResponse> request,
-            CancellationToken cancellationToken = default) =>
-            Task.FromResult(default(TResponse)!);
+    public Task<TResponse> Send<TResponse>(IRequest<TResponse> request,
+        CancellationToken cancellationToken = default) =>
+        Task.FromResult(default(TResponse)!);
 
-        public Task<object?> Send(object request, CancellationToken cancellationToken = default) =>
-            Task.FromResult(default(object));
+    public Task Send<TRequest>(TRequest request, CancellationToken cancellationToken = new())
+        where TRequest : IRequest => Task.CompletedTask;
 
-#if NETSTANDARD2_1_OR_GREATER
-        public IAsyncEnumerable<TResponse> CreateStream<TResponse>(IStreamRequest<TResponse> request,
-            CancellationToken cancellationToken = new()) =>
-            throw new System.NotImplementedException();
+    public Task<object?> Send(object request, CancellationToken cancellationToken = default) =>
+        Task.FromResult(default(object));
 
-        public IAsyncEnumerable<object?> CreateStream(object request,
-            CancellationToken cancellationToken = new()) =>
-            throw new System.NotImplementedException();
-#endif
-    }
+    public IAsyncEnumerable<TResponse> CreateStream<TResponse>(IStreamRequest<TResponse> request,
+        CancellationToken cancellationToken = new()) =>
+        throw new NotImplementedException();
+
+    public IAsyncEnumerable<object?> CreateStream(object request,
+        CancellationToken cancellationToken = new()) =>
+        throw new NotImplementedException();
 }

--- a/Enigmatry.Entry.MediatR/ValidationBehavior.cs
+++ b/Enigmatry.Entry.MediatR/ValidationBehavior.cs
@@ -17,7 +17,7 @@ namespace Enigmatry.Entry.MediatR
             _validators = validators;
         }
 
-        public Task<TResponse> Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<TResponse> next)
+        public Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
         {
             var failures = _validators
                 .Select(v => v.Validate(request))

--- a/Enigmatry.Entry.Scheduler.Tests/Enigmatry.Entry.Scheduler.Tests.csproj
+++ b/Enigmatry.Entry.Scheduler.Tests/Enigmatry.Entry.Scheduler.Tests.csproj
@@ -25,7 +25,10 @@
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
     <PackageReference Include="FluentAssertions" />
-    <PackageReference Include="NUnit.Analyzers" />
+    <PackageReference Include="NUnit.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Verify.NUnit" />
   </ItemGroup>
 

--- a/Enigmatry.Entry.Scheduler.Tests/SchedulingConfigurationBuilder.cs
+++ b/Enigmatry.Entry.Scheduler.Tests/SchedulingConfigurationBuilder.cs
@@ -15,7 +15,7 @@ public class SchedulingConfigurationBuilder
     {
 #pragma warning disable IDE0055
         // this configuration reflects jobs found in SampleJobs.cs
-        var items = new Dictionary<string, string>
+        var items = new Dictionary<string, string?>
         {
             { "Scheduling:Host", "HostName" },
 

--- a/Enigmatry.Entry.Scheduler/ConfigurationExtensions.cs
+++ b/Enigmatry.Entry.Scheduler/ConfigurationExtensions.cs
@@ -15,7 +15,7 @@ internal static class ConfigurationExtensions
         var schedulingSection = configuration.GetSchedulingSection();
         var jobSection = schedulingSection.GetSection($"Jobs:{jobName}");
         var settings = jobSection.Get<JobSettings>();
-        return new JobConfiguration(jobName, jobType, settings, jobSection);
+        return new JobConfiguration(jobName, jobType, settings!, jobSection);
     }
 
     private static IConfigurationSection GetSchedulingSection(this IConfiguration configuration)

--- a/Enigmatry.Entry.Scheduler/ServiceCollectionExtensions.cs
+++ b/Enigmatry.Entry.Scheduler/ServiceCollectionExtensions.cs
@@ -20,7 +20,6 @@ public static class ServiceCollectionExtensions
 
         services.AddQuartz(quartz =>
         {
-            quartz.UseMicrosoftDependencyInjectionJobFactory();
             quartz.AddJobs(configuration, assembly, logger);
         });
 

--- a/Enigmatry.Entry.TemplatingEngine.Tests/Enigmatry.Entry.TemplatingEngine.Tests.csproj
+++ b/Enigmatry.Entry.TemplatingEngine.Tests/Enigmatry.Entry.TemplatingEngine.Tests.csproj
@@ -15,8 +15,14 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
-    <PackageReference Include="NUnit.Analyzers" />
-    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="NUnit.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Enigmatry.Entry.TemplatingEngine.Tests/Enigmatry.Entry.TemplatingEngine.Tests.csproj
+++ b/Enigmatry.Entry.TemplatingEngine.Tests/Enigmatry.Entry.TemplatingEngine.Tests.csproj
@@ -9,7 +9,8 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="JetBrains.Annotations" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" VersionOverride="6.0.24" Condition=" '$(TargetFramework)' == 'net6.0' " />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Condition=" '$(TargetFramework)' == 'net7.0' " />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />

--- a/Enigmatry.Entry.TemplatingEngine/Enigmatry.Entry.TemplatingEngine.csproj
+++ b/Enigmatry.Entry.TemplatingEngine/Enigmatry.Entry.TemplatingEngine.csproj
@@ -10,7 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" VersionOverride="6.0.24" Condition=" '$(TargetFramework)' == 'net6.0' " />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Condition=" '$(TargetFramework)' == 'net7.0' " />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" />
   </ItemGroup>


### PR DESCRIPTION
https://enigmatry.atlassian.net/browse/BP-634 Update all .NET nuget packages in the building blocks

- Disable warning EnableGenerateDocumentationFile introduced in VS 2022 17.7.5 (https://github.com/dotnet/roslyn/issues/41640)
- Remove unused packages from Directory.Packages.props
- Remove unused dependency FluentValidation.AspNetCore
- Remove deprecated dependency Microsoft.Rest.ClientRuntime
- Update dependencies:
  * AspNetCore.HealthChecks.System to 7.0.0
  * AutoMapper to 12.0.1
  * Azure.Identity to 1.10.3
  * Azure.Storage.Blobs to 12.18.0
  * CachingFramework.Redis to 15.0.2
  * CachingFramework.Redis.NewtonsoftJson to 15.0.2
  * coverlet.collector to 6.0.0
  * coverlet.msbuild to 6.0.0
  * CsvHelper to 30.0.1
  * EmailValidation to 1.0.10
  * FakeItEasy to 7.4.0
  * FakeItEasy.Analyzer.CSharp to 6.1.1
  * FluentAssertions to 6.12.0
  * FluentValidation to 11.8.0
  * JetBrains.Annotations to 2023.2.0
  * MailKit to 4.2.0
  * MediatR to 12.1.1
  * Microsoft.AspNet.WebApi.Client to 6.0.0
  * Microsoft.AspNetCore.Mvc.NewtonsoftJson to 7.0.13
  * Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation to 7.0.13
  * Microsoft.AspNetCore.Mvc.Testing to 7.0.13
  * Microsoft.EntityFrameworkCore to 7.0.13
  * Microsoft.EntityFrameworkCore.SqlServer to 7.0.13
  * Microsoft.Extensions.Caching.Abstractions to 7.0.0
  * Microsoft.Extensions.Configuration to 7.0.0
  * Microsoft.Extensions.Configuration.Abstractions to 7.0.0
  * Microsoft.Extensions.Configuration.Binder to 7.0.4
  * Microsoft.Extensions.Configuration.EnvironmentVariables to 7.0.0
  * Microsoft.Extensions.Configuration.UserSecrets to 7.0.0
  * Microsoft.Extensions.DependencyInjection to 7.0.0
  * Microsoft.Extensions.FileProviders.Physical to 7.0.0
  * Microsoft.Extensions.Hosting.Abstractions to 7.0.0
  * Microsoft.Extensions.Logging to 7.0.0
  * Microsoft.Extensions.Logging.Abstractions to 7.0.1
  * Microsoft.Extensions.Logging.Console to 7.0.0
  * Microsoft.Extensions.Options to 7.0.1
  * Microsoft.Extensions.Options.ConfigurationExtensions to 7.0.0
  * Microsoft.NET.Test.Sdk to 17.7.2
  * MimeKit to 4.2.0
  * Newtonsoft.Json to 13.0.3
  * NSwag.AspNetCore to 13.20.0
  * NUnit.Analyzers to 3.8.0
  * NUnit3TestAdapter to 4.5.0
  * Polly to 8.0.0
  * Quartz to 3.7.0
  * Quartz.Extensions.DependencyInjection to 3.7.0
  * Quartz.Extensions.Hosting to 3.7.0
  * Serilog to 3.0.1
  * System.Linq.Dynamic.Core to 1.3.5
  * System.Net.Http.Json to 7.0.1
  * Verify.NUnit to 22.1.4
- Fix warnings