### PR TITLE
Bp 1165 extend db context settings

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -46,10 +46,10 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Graph" Version="4.36.0" />
+    <PackageVersion Include="Microsoft.Graph" Version="4.37.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
-    <PackageVersion Include="MimeKit" Version="4.6.0" />
+    <PackageVersion Include="MimeKit" Version="4.7.1" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="NJsonSchema" Version="11.0.1" />
     <PackageVersion Include="NSwag.AspNetCore" Version="14.0.8" />

--- a/Enigmatry.Entry.AspNetCore.Authorization.Tests/PermissionTypeConverterFixture.cs
+++ b/Enigmatry.Entry.AspNetCore.Authorization.Tests/PermissionTypeConverterFixture.cs
@@ -6,6 +6,7 @@ using NUnit.Framework;
 
 namespace Enigmatry.Entry.AspNetCore.Authorization.Tests;
 
+[NUnit.Framework.Category("unit")]
 public class PermissionTypeConverterFixture
 {
     [Test]

--- a/Enigmatry.Entry.AspNetCore.Tests/ExceptionHandlerFixture.cs
+++ b/Enigmatry.Entry.AspNetCore.Tests/ExceptionHandlerFixture.cs
@@ -9,6 +9,7 @@ using System.Text.Json;
 
 namespace Enigmatry.Entry.AspNetCore.Tests;
 
+[Category("unit")]
 public class ExceptionHandlerFixture
 {
     [Test]

--- a/Enigmatry.Entry.AspNetCore.Tests/HandleExceptionsFilterFixture.cs
+++ b/Enigmatry.Entry.AspNetCore.Tests/HandleExceptionsFilterFixture.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Enigmatry.Entry.AspNetCore.Tests;
 
+[Category("unit")]
 [Obsolete("ExceptionsFilter is deprecated due to limited context, please use extensions method instead since more exceptions can be caught from it.")]
 public class HandleExceptionsFilterFixture
 {

--- a/Enigmatry.Entry.Core/Settings/DbContextSettings.cs
+++ b/Enigmatry.Entry.Core/Settings/DbContextSettings.cs
@@ -1,13 +1,16 @@
 ﻿using System;
+using JetBrains.Annotations;
 
-namespace Enigmatry.Entry.Core.Settings
+namespace Enigmatry.Entry.Core.Settings;
+
+[PublicAPI]
+public class DbContextSettings
 {
-    public class DbContextSettings
-    {
-        public bool SensitiveDataLoggingEnabled { get; set; }
+    public bool SensitiveDataLoggingEnabled { get; set; }
 
-        public int ConnectionResiliencyMaxRetryCount { get; set; }
+    public int ConnectionResiliencyMaxRetryCount { get; set; }
 
-        public TimeSpan ConnectionResiliencyMaxRetryDelay { get; set; }
-    }
+    public TimeSpan ConnectionResiliencyMaxRetryDelay { get; set; }
+
+    public bool RegisterMigrationsAssembly { get; set; }
 }

--- a/Enigmatry.Entry.Email.Tests/packages.lock.json
+++ b/Enigmatry.Entry.Email.Tests/packages.lock.json
@@ -74,8 +74,8 @@
       },
       "BouncyCastle.Cryptography": {
         "type": "Transitive",
-        "resolved": "2.3.1",
-        "contentHash": "buwoISwecYke3CmgG1AQSg+sNZjJeIb93vTAtJiHZX35hP/teYMxsfg0NDXGUKjGx6BKBTNKc77O2M3vKvlXZQ=="
+        "resolved": "2.4.0",
+        "contentHash": "SwXsAV3sMvAU/Nn31pbjhWurYSjJ+/giI/0n6tCrYoupEK34iIHCuk3STAd9fx8yudM85KkLSVdn951vTng/vQ=="
       },
       "MediatR.Contracts": {
         "type": "Transitive",
@@ -119,8 +119,8 @@
       },
       "System.Formats.Asn1": {
         "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "AJukBuLoe3QeAF+mfaRKQb2dgyrvt340iMBHYv+VdBzCUM06IxGlvl0o/uPOS7lHnXPN6u8fFRHSHudx5aTi8w=="
+        "resolved": "8.0.1",
+        "contentHash": "XqKba7Mm/koKSjKMfW82olQdmfbI5yqeoLV/tidRp7fbh5rmHAQ5raDI/7SU0swTzv+jgqtUGkzmFxuUg0it1A=="
       },
       "System.Reflection.Metadata": {
         "type": "Transitive",
@@ -160,7 +160,7 @@
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[8.0.1, )",
           "Microsoft.Extensions.Options": "[8.0.2, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[8.0.0, )",
-          "MimeKit": "[4.6.0, )"
+          "MimeKit": "[4.7.1, )"
         }
       },
       "EmailValidation": {
@@ -258,11 +258,12 @@
       },
       "MimeKit": {
         "type": "CentralTransitive",
-        "requested": "[4.6.0, )",
-        "resolved": "4.6.0",
-        "contentHash": "M4jddPQNSClTzHE+HnfrtN93mCXSYF8KewWUTwzXgl49ajzUh8hz/UY4CAnRQR4YJF3lBY5P+r+73VXZAGKafw==",
+        "requested": "[4.7.1, )",
+        "resolved": "4.7.1",
+        "contentHash": "Qoj4aVvhX14A1FNvaJ33hzOP4VZI2j+Mr38I9wSGcjMq4BYDtWLJG89aJ9nRW2cNfH6Czjwyp7+Mh++xv3AZvg==",
         "dependencies": {
-          "BouncyCastle.Cryptography": "2.3.1",
+          "BouncyCastle.Cryptography": "2.4.0",
+          "System.Formats.Asn1": "8.0.1",
           "System.Security.Cryptography.Pkcs": "8.0.0"
         }
       },

--- a/Enigmatry.Entry.EmailClient/packages.lock.json
+++ b/Enigmatry.Entry.EmailClient/packages.lock.json
@@ -70,18 +70,19 @@
       },
       "MimeKit": {
         "type": "Direct",
-        "requested": "[4.6.0, )",
-        "resolved": "4.6.0",
-        "contentHash": "M4jddPQNSClTzHE+HnfrtN93mCXSYF8KewWUTwzXgl49ajzUh8hz/UY4CAnRQR4YJF3lBY5P+r+73VXZAGKafw==",
+        "requested": "[4.7.1, )",
+        "resolved": "4.7.1",
+        "contentHash": "Qoj4aVvhX14A1FNvaJ33hzOP4VZI2j+Mr38I9wSGcjMq4BYDtWLJG89aJ9nRW2cNfH6Czjwyp7+Mh++xv3AZvg==",
         "dependencies": {
-          "BouncyCastle.Cryptography": "2.3.1",
+          "BouncyCastle.Cryptography": "2.4.0",
+          "System.Formats.Asn1": "8.0.1",
           "System.Security.Cryptography.Pkcs": "8.0.0"
         }
       },
       "BouncyCastle.Cryptography": {
         "type": "Transitive",
-        "resolved": "2.3.1",
-        "contentHash": "buwoISwecYke3CmgG1AQSg+sNZjJeIb93vTAtJiHZX35hP/teYMxsfg0NDXGUKjGx6BKBTNKc77O2M3vKvlXZQ=="
+        "resolved": "2.4.0",
+        "contentHash": "SwXsAV3sMvAU/Nn31pbjhWurYSjJ+/giI/0n6tCrYoupEK34iIHCuk3STAd9fx8yudM85KkLSVdn951vTng/vQ=="
       },
       "MediatR.Contracts": {
         "type": "Transitive",
@@ -105,8 +106,8 @@
       },
       "System.Formats.Asn1": {
         "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "AJukBuLoe3QeAF+mfaRKQb2dgyrvt340iMBHYv+VdBzCUM06IxGlvl0o/uPOS7lHnXPN6u8fFRHSHudx5aTi8w=="
+        "resolved": "8.0.1",
+        "contentHash": "XqKba7Mm/koKSjKMfW82olQdmfbI5yqeoLV/tidRp7fbh5rmHAQ5raDI/7SU0swTzv+jgqtUGkzmFxuUg0it1A=="
       },
       "System.Security.Cryptography.Pkcs": {
         "type": "Transitive",

--- a/Enigmatry.Entry.EntityFramework.Tests/PublishDomainEventsInterceptorTests.cs
+++ b/Enigmatry.Entry.EntityFramework.Tests/PublishDomainEventsInterceptorTests.cs
@@ -10,6 +10,7 @@ using NUnit.Framework;
 
 namespace Enigmatry.Entry.EntityFramework.Tests;
 
+[Category("unit")]
 public class PublishDomainEventsInterceptorTests
 {
     private IServiceScope _testScope = null!;

--- a/Enigmatry.Entry.GraphApi/packages.lock.json
+++ b/Enigmatry.Entry.GraphApi/packages.lock.json
@@ -34,11 +34,11 @@
       },
       "Microsoft.Graph": {
         "type": "Direct",
-        "requested": "[4.36.0, )",
-        "resolved": "4.36.0",
-        "contentHash": "KFsVgiQb7pyCZgD7oMkFGtq8jXdMc1n5W3mnsXSR7CkVvIOHKtddsWA01WxVYwfYpDO6lA0xRa/oeB2El574tw==",
+        "requested": "[4.37.0, )",
+        "resolved": "4.37.0",
+        "contentHash": "XfbRLmmyJkNcNFbjC+FP+LgeFiOk2cNn7TeLh9A2T24UXCwy8Kz4rKTvfmdgYUAO8fcSe4kkGNOmfG1H6Myktg==",
         "dependencies": {
-          "Microsoft.Graph.Core": "2.0.11"
+          "Microsoft.Graph.Core": "2.0.12"
         }
       },
       "Microsoft.SourceLink.GitHub": {
@@ -88,11 +88,11 @@
       },
       "Microsoft.Graph.Core": {
         "type": "Transitive",
-        "resolved": "2.0.11",
-        "contentHash": "okcJnzEndl+JQ0ymjfH4Zg6xKqrNijU6iJVJ4NOtMyz83wCP2kYigNRTHWLjMuu6BXuaPxEkZuxx0PlrWBuBXQ==",
+        "resolved": "2.0.12",
+        "contentHash": "3a6vQADJMDJX0ZrU+lVYjlJxpsDAJNUmgB8vXodwrlGHkHJP7TqsQZ43MeU35XkoPfWtEj06+Hed3SLFlkoqAg==",
         "dependencies": {
           "Azure.Core": "1.25.0",
-          "Microsoft.Identity.Client": "4.46.0",
+          "Microsoft.Identity.Client": "4.46.1",
           "Microsoft.IdentityModel.Protocols.OpenIdConnect": "6.22.0",
           "System.Diagnostics.DiagnosticSource": "4.7.1",
           "System.Net.Http": "4.3.4",
@@ -218,7 +218,7 @@
       "runtime.native.System.Security.Cryptography.Apple": {
         "type": "Transitive",
         "resolved": "4.3.0",
-        "contentHash": "DloMk88juo0OuOWr56QG7MNchmafTLYWvABy36izkrLI5VledI0rq28KGs1i9wbpeT9NPQrx/wTf8U2vazqQ3Q==",
+        "contentHash": "jwjwlEL0Elv6gwoyaokRn12nv/JE+UW/DXJEbzhjCPvGbef36StnHKc9XaZD/rGWqYicrphZ7eumR/jdmNcjRg==",
         "dependencies": {
           "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple": "4.3.0"
         }
@@ -253,7 +253,7 @@
       "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple": {
         "type": "Transitive",
         "resolved": "4.3.0",
-        "contentHash": "kVXCuMTrTlxq4XOOMAysuNwsXWpYeboGddNGpIgNSZmv1b6r/s/DPk0fYMB7Q5Qo4bY68o48jt4T4y5BVecbCQ=="
+        "contentHash": "Kh9W4agE0r/hK8AX1LvyQI2NrKHBL8pO0gRoDTdDb0LL6Ta1Z2OtFx3lOaAE0ZpCUc/dt9Wzs3rA7a3IsKdOVA=="
       },
       "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
         "type": "Transitive",


### PR DESCRIPTION
Add RegisterMigrationsAssembly  to the DbContextSettings so that we don't need to have custom DbContextSettings with one additional property in each project