### PR TITLE
https://enigmatry.atlassian.net/browse/BP-1629 Scheduler Building Block: pass cancellation token to Execute method

### DIFF
--- a/Enigmatry.Entry.Scheduler/EntryJob.cs
+++ b/Enigmatry.Entry.Scheduler/EntryJob.cs
@@ -17,7 +17,7 @@ public abstract class EntryJob<T>(ILogger<EntryJob<T>> logger, IConfiguration co
         try
         {
             var jobType = GetType();
-            await Execute(configuration.GetJobConfiguration(jobType).GetSchedulingJobArgumentsValue<T>());
+            await Execute(configuration.GetJobConfiguration(jobType).GetSchedulingJobArgumentsValue<T>(), context.CancellationToken);
             logger.LogInformation("{JobName} job completed.", jobName);
         }
         catch (Exception ex)
@@ -27,4 +27,6 @@ public abstract class EntryJob<T>(ILogger<EntryJob<T>> logger, IConfiguration co
     }
 
     public abstract Task Execute(T request);
+
+    protected virtual Task Execute(T request, CancellationToken cancellationToken) => Execute(request);
 }


### PR DESCRIPTION
Currently, the Scheduler Building Block's Execute method does not accept a CancellationToken, making it impossible to gracefully cancel long-running or stuck scheduled jobs. This change passes a CancellationToken into the Execute method, allowing job implementations to observe cancellation requests and stop work cooperatively. This improves shutdown behaviour, resource usage, and overall resilience of scheduled tasks.